### PR TITLE
Big Pokemon Icons Option

### DIFF
--- a/Data/Scripts/007_Objects and windows/008_AnimatedBitmap.rb
+++ b/Data/Scripts/007_Objects and windows/008_AnimatedBitmap.rb
@@ -193,8 +193,10 @@ class AnimatedBitmap
 
   def scale_bitmap(scale)
     return if scale == 1
-    new_width = @bitmap.bitmap.width * scale
-    new_height = @bitmap.bitmap.height * scale
+    new_width = (@bitmap.bitmap.width * scale).floor #Sylvi Big Icons
+    new_height = (@bitmap.bitmap.height * scale).floor #Sylvi Big Icons
+
+    return if new_width <= 0 || new_height <= 0 #Sylvi Big Icons
 
     destination_rect = Rect.new(0, 0, new_width, new_height)
     source_rect = Rect.new(0, 0, @bitmap.bitmap.width, @bitmap.bitmap.height)

--- a/Data/Scripts/014_Pokemon/001_Pokemon-related/003_Pokemon_Sprites.rb
+++ b/Data/Scripts/014_Pokemon/001_Pokemon-related/003_Pokemon_Sprites.rb
@@ -103,6 +103,9 @@ class PokemonIconSprite < SpriteWrapper
   attr_accessor :selected
   attr_accessor :active
   attr_reader :pokemon
+  #Sylvi Big Icons
+  attr_accessor :icon_offset_x
+  attr_accessor :icon_offset_y
 
   def initialize(pokemon, viewport = nil)
     super(viewport)
@@ -111,11 +114,15 @@ class PokemonIconSprite < SpriteWrapper
     @numFrames = 0
     @currentFrame = 0
     @counter = 0
-    self.pokemon = pokemon
+    #self.pokemon = pokemon
     @logical_x = 0 # Actual x coordinate
     @logical_y = 0 # Actual y coordinate
     @adjusted_x = 0 # Offset due to "jumping" animation in party screen
     @adjusted_y = 0 # Offset due to "jumping" animation in party screen
+    #Sylvi Big Icons
+    @icon_offset_x = -16 # Offset to center big sprite icons (if enabled)
+    @icon_offset_y = 0 # Offset to center big sprite icons (if enabled)
+    self.pokemon = pokemon
   end
 
   def dispose
@@ -133,16 +140,39 @@ class PokemonIconSprite < SpriteWrapper
 
   def x=(value)
     @logical_x = value
-    super(@logical_x + @adjusted_x)
+    #Sylvi Big Icons
+    ret = @logical_x + @adjusted_x
+    if self.use_big_icon?
+      if @pokemon && @pokemon.egg?
+        ret += (@icon_offset_x / 2)
+      else
+        ret += @icon_offset_x
+      end
+    end
+    super(ret)
   end
 
   def y=(value)
     @logical_y = value
-    super(@logical_y + @adjusted_y)
+    #Sylvi Big Icons
+    ret = @logical_y + @adjusted_y
+    if self.use_big_icon?
+      if @pokemon && @pokemon.egg?
+        ret += (@icon_offset_y / 2)
+      else
+        ret += @icon_offset_y
+      end
+    end
+    super(ret)
   end
 
   def animBitmap=(value)
     @animBitmap = value
+  end
+
+  #Sylvi Big Icons
+  def use_big_icon?
+    return $PokemonSystem.kuraybigicons == 1 || $PokemonSystem.kuraybigicons == 2
   end
 
   #KurayX - KURAYX_ABOUT_SHINIES
@@ -157,7 +187,16 @@ class PokemonIconSprite < SpriteWrapper
       @counter = 0
       return
     end
-    if @pokemon.egg?
+
+    if self.use_big_icon?
+      #Sylvi Big Icons
+      @animBitmap = GameData::Species.sprite_bitmap_from_pokemon(@pokemon)
+      if @pokemon.egg?
+        @animBitmap.scale_bitmap(1.0/2.0)
+      else
+        @animBitmap.scale_bitmap(1.0/3.0)
+      end
+    elsif @pokemon.egg?
       @animBitmap = AnimatedBitmap.new(GameData::Species.icon_filename_from_pokemon(@pokemon))
     elsif useRegularIcon(@pokemon.species)
       # @animBitmap = AnimatedBitmap.new(GameData::Species.icon_filename(@pokemon.species, @pokemon.form, @pokemon.gender, @pokemon.shiny?))

--- a/Data/Scripts/016_UI/005_UI_Party.rb
+++ b/Data/Scripts/016_UI/005_UI_Party.rb
@@ -221,10 +221,13 @@ class PokemonPartyPanel < SpriteWrapper
     @hpbgsprite.addBitmap("able", "Graphics/Pictures/Party/overlay_hp_back")
     @hpbgsprite.addBitmap("fainted", "Graphics/Pictures/Party/overlay_hp_back_faint")
     @hpbgsprite.addBitmap("swap", "Graphics/Pictures/Party/overlay_hp_back_swap")
-    @ballsprite = ChangelingSprite.new(0, 0, viewport)
-    @ballsprite.z = self.z + 1
-    @ballsprite.addBitmap("desel", "Graphics/Pictures/Party/icon_ball")
-    @ballsprite.addBitmap("sel", "Graphics/Pictures/Party/icon_ball_sel")
+    #Sylvi Big Icons
+    if $PokemonSystem.kuraybigicons == 0 || !@pokemon then
+      @ballsprite = ChangelingSprite.new(0, 0, viewport)
+      @ballsprite.z = self.z + 1
+      @ballsprite.addBitmap("desel", "Graphics/Pictures/Party/icon_ball")
+      @ballsprite.addBitmap("sel", "Graphics/Pictures/Party/icon_ball_sel")
+    end
     @pkmnsprite = PokemonIconSprite.new(pokemon, viewport)
     @pkmnsprite.setOffset(PictureOrigin::Center)
     @pkmnsprite.active = @active
@@ -247,7 +250,7 @@ class PokemonPartyPanel < SpriteWrapper
   def dispose
     @panelbgsprite.dispose
     @hpbgsprite.dispose
-    @ballsprite.dispose
+    @ballsprite.dispose if @ballsprite #Sylvi Big Icons
     @pkmnsprite.dispose
     @helditemsprite.dispose
     @overlaysprite.bitmap.dispose

--- a/Data/Scripts/016_UI/006_UI_Summary.rb
+++ b/Data/Scripts/016_UI/006_UI_Summary.rb
@@ -131,6 +131,9 @@ class PokemonSummary_Scene
       @sprites["pokemon"].zoom_y = Settings::FRONTSPRITE_SCALE
     end
     @sprites["pokeicon"] = PokemonIconSprite.new(@pokemon, @viewport)
+    #Sylvi Big Icons
+    @sprites["pokeicon"].icon_offset_x = 0
+    @sprites["pokeicon"].icon_offset_y = 0
     @sprites["pokeicon"].setOffset(PictureOrigin::Center)
     @sprites["pokeicon"].x = 46
     @sprites["pokeicon"].y = 92
@@ -191,6 +194,9 @@ class PokemonSummary_Scene
     @sprites["overlay"] = BitmapSprite.new(Graphics.width, Graphics.height, @viewport)
     pbSetSystemFont(@sprites["overlay"].bitmap)
     @sprites["pokeicon"] = PokemonIconSprite.new(@pokemon, @viewport)
+    #Sylvi Big Icons
+    @sprites["pokeicon"].icon_offset_x = 0
+    @sprites["pokeicon"].icon_offset_y = 0
     @sprites["pokeicon"].setOffset(PictureOrigin::Center)
     @sprites["pokeicon"].x = 46
     @sprites["pokeicon"].y = 92

--- a/Data/Scripts/016_UI/015_UI_Options.rb
+++ b/Data/Scripts/016_UI/015_UI_Options.rb
@@ -29,6 +29,7 @@ class PokemonSystem
   attr_accessor :kurayshinyanim
   attr_accessor :kurayfonts
   attr_accessor :shenanigans
+  attr_accessor :kuraybigicons
 
   def initialize
     @textspeed = 1 # Text speed (0=slow, 1=normal, 2=fast)
@@ -58,6 +59,7 @@ class PokemonSystem
     @kuraygambleodds = 100
     @kurayqol = 1
     @shenanigans = 0
+    @kuraybigicons = 0
 
   end
 end
@@ -629,6 +631,14 @@ class PokemonOption_Scene
                                  "Uses the same party icon for all fusions"]
       )
     end
+    #Sylvi Big Icons
+    options << EnumOption.new(_INTL("Big Pokémon Icons"), [_INTL("Off"), _INTL("Limited"), _INTL("All")],
+                              proc { $PokemonSystem.kuraybigicons },
+                              proc { |value| $PokemonSystem.kuraybigicons = value },
+                              ["Pokémon will use their small box sprites for icons",
+                               "Pokémon icons will use their full-size battle sprites (except in boxes)",
+                               "Pokémon icons will use their full-size battle sprites"]
+    )
     options << EnumOption.new(_INTL("Screen Size"), [_INTL("S"), _INTL("M"), _INTL("L"), _INTL("XL"), _INTL("Full")],
                               proc { [$PokemonSystem.screensize, 4].min },
                               proc { |value|

--- a/Data/Scripts/016_UI/017_UI_PokemonStorage.rb
+++ b/Data/Scripts/016_UI/017_UI_PokemonStorage.rb
@@ -7,6 +7,11 @@ class PokemonBoxIcon < IconSprite
   attr_accessor :pokemon
 
   def initialize(pokemon, viewport = nil)
+    #Sylvi Big Icons
+    @logical_x = 0 # Actual x coordinate
+    @logical_y = 0 # Actual y coordinate
+    @icon_offset_x = 0 # Offset to center big sprite icons (if enabled)
+    @icon_offset_y = 0 # Offset to center big sprite icons (if enabled)
     super(0, 0, viewport)
     @pokemon = pokemon
     @release = Interpolator.new
@@ -14,6 +19,33 @@ class PokemonBoxIcon < IconSprite
     @heldox = 0
     @heldoy = 0
     refresh
+  end
+  
+  #Sylvi Big Icons
+  def x
+    return @logical_x
+  end
+
+  #Sylvi Big Icons
+  def y
+    return @logical_y
+  end
+
+  #Sylvi Big Icons
+  def x=(value)
+    @logical_x = value
+    super(@logical_x + @icon_offset_x)
+  end
+
+  #Sylvi Big Icons
+  def y=(value)
+    @logical_y = value
+    super(@logical_y + @icon_offset_y)
+  end
+
+  #Sylvi Big Icons
+  def use_big_icon?
+    return $PokemonSystem && $PokemonSystem.kuraybigicons == 2
   end
 
   def releasing?
@@ -219,7 +251,20 @@ class PokemonBoxIcon < IconSprite
   #KurayX - KURAYX_ABOUT_SHINIES
   def refresh(fusion_enabled = true)
     return if !@pokemon
-    if @pokemon.egg?
+    if self.use_big_icon?
+      #Sylvi Big Icons
+      tempBitmap = GameData::Species.sprite_bitmap_from_pokemon(@pokemon)
+      if @pokemon.egg?
+        tempBitmap.scale_bitmap(1.0/2.0)
+        @icon_offset_x = -8
+        @icon_offset_y = -8
+      else
+        tempBitmap.scale_bitmap(1.0/3.0)
+        @icon_offset_x = -16
+        @icon_offset_y = -16
+      end
+      self.setBitmapDirectly(tempBitmap)
+    elsif @pokemon.egg?
       self.setBitmap(GameData::Species.icon_filename_from_pokemon(@pokemon))
     elsif useRegularIcon(@pokemon.species)
       self.setBitmapDirectly(createRBGableShiny(@pokemon))
@@ -911,6 +956,20 @@ class PokemonBoxPartySprite < SpriteWrapper
     refresh
   end
 
+  #Sylvi Big Icons
+  def hidePokemon
+    for i in 0...Settings::MAX_PARTY_SIZE
+      @pokemonsprites[i].visible = false if @pokemonsprites[i]
+    end
+  end
+
+  #Sylvi Big Icons
+  def showPokemon
+    for i in 0...Settings::MAX_PARTY_SIZE
+      @pokemonsprites[i].visible = true if @pokemonsprites[i]
+    end
+  end
+
   def refresh
     @contents.blt(0, 0, @boxbitmap.bitmap, Rect.new(0, 0, 172, 352))
     pbDrawTextPositions(self.bitmap, [
@@ -1004,6 +1063,7 @@ class PokemonStorageScene
     if command != 2 # Drop down tab only on Deposit
       @sprites["boxparty"].x = 182
       @sprites["boxparty"].y = Graphics.height
+      @sprites["boxparty"].hidePokemon #Sylvi Big Icons
     end
     @markingbitmap = AnimatedBitmap.new("Graphics/Pictures/Storage/markings")
     @sprites["markingbg"] = IconSprite.new(292, 68, @boxsidesviewport)
@@ -1512,6 +1572,7 @@ class PokemonStorageScene
 
   def pbShowPartyTab
     pbSEPlay("GUI storage show party panel")
+    @sprites["boxparty"].showPokemon #Sylvi Big Icons
     distancePerFrame = 48 * 20 / Graphics.frame_rate
     loop do
       Graphics.update
@@ -1534,6 +1595,7 @@ class PokemonStorageScene
       break if @sprites["boxparty"].y >= Graphics.height
     end
     @sprites["boxparty"].y = Graphics.height
+    @sprites["boxparty"].hidePokemon #Sylvi Big Icons
   end
 
   def pbHold(selected)
@@ -2171,6 +2233,12 @@ class PokemonStorageScene
     @sprites["boxparty"].dispose
     @sprites["boxparty"] = PokemonBoxPartySprite.new(@storage.party, @boxsidesviewport)
     @sprites["boxparty"].y = oldPartyY
+    #Sylvi Big Icons
+    if @sprites["boxparty"].y >= Graphics.height
+      @sprites["boxparty"].hidePokemon
+    else
+      @sprites["boxparty"].showPokemon
+    end
   end
 
   def drawMarkings(bitmap, x, y, _width, _height, markings)

--- a/Data/Scripts/016_UI/024_UI_TextEntry.rb
+++ b/Data/Scripts/016_UI/024_UI_TextEntry.rb
@@ -140,6 +140,9 @@ class PokemonEntryScene
         @sprites["shadow"].x=33*2
         @sprites["shadow"].y=32*2
         @sprites["subject"]=PokemonIconSprite.new(pokemon,@viewport)
+        #Sylvi Big Icons
+        @sprites["subject"].icon_offset_x = 0
+        @sprites["subject"].icon_offset_y = 0
         @sprites["subject"].setOffset(PictureOrigin::Center)
         @sprites["subject"].x=88
         @sprites["subject"].y=54
@@ -445,6 +448,9 @@ class PokemonEntryScene2
         @sprites["shadow"].x = 66
         @sprites["shadow"].y = 64
         @sprites["subject"] = PokemonIconSprite.new(pokemon, @viewport)
+        #Sylvi Big Icons
+        @sprites["subject"].icon_offset_x = 0
+        @sprites["subject"].icon_offset_y = 0
         @sprites["subject"].setOffset(PictureOrigin::Center)
         @sprites["subject"].x = 88
         @sprites["subject"].y = 54


### PR DESCRIPTION
Adds an option that changes pokemon icons to display the full-sized battle sprite instead of the small box icon, with a "limited" option that makes box sprites stay the same and change only the party menu

![screen-017762](https://github.com/kurayamiblackheart/kurayshinyrevamp/assets/89804482/e0084fc8-aada-4553-a3b0-05d1a3f28fbf)
![screen-017763](https://github.com/kurayamiblackheart/kurayshinyrevamp/assets/89804482/a2edcbee-ee59-486c-8a61-a3d4560dd620)
