### PR TITLE
Update 006_AI_Move_Utilities.rb

### DIFF
--- a/Data/Scripts/011_Battle/004_AI/006_AI_Move_Utilities.rb
+++ b/Data/Scripts/011_Battle/004_AI/006_AI_Move_Utilities.rb
@@ -79,12 +79,12 @@ class PokeBattle_AI
 
   # For switching. Determines the effectiveness of a potential switch-in against
   # an opposing battler.
-  def pbCalcTypeModPokemon(battlerThis,_battlerOther)
+  def pbCalcTypeModPokemon(battlerThis,target)
     mod1 = Effectiveness.calculate(battlerThis.type1,target.type1,target.type2)
     mod2 = Effectiveness::NORMAL_EFFECTIVE
     if battlerThis.type1!=battlerThis.type2
       mod2 = Effectiveness.calculate(battlerThis.type2,target.type1,target.type2)
-      mod2 = mod2.to_f / Effectivenesss::NORMAL_EFFECTIVE
+      mod2 = mod2.to_f / Effectiveness::NORMAL_EFFECTIVE
     end
     return mod1*mod2
   end


### PR DESCRIPTION
# Bugfixes
'_battlerOther' not used (replaced with target), 'effectivenesss' typo