### PR TITLE
refactor prevo move relearner and fix wild pokemon moves

### DIFF
--- a/Data/Scripts/011_Battle/003_Battle/004_Battle_ExpAndMoveLearning.rb
+++ b/Data/Scripts/011_Battle/003_Battle/004_Battle_ExpAndMoveLearning.rb
@@ -246,7 +246,7 @@ class PokeBattle_Battle
                         oldSpAtk, oldSpDef, oldSpeed)
       end
       # Learn all moves learned at this level
-      moveList = pkmn.getMLStandard
+      moveList = pkmn.getMoveList
       moveList.each { |m| pbLearnMove(idxParty, m[1]) if m[0] == curLevel }
     end
   end

--- a/Data/Scripts/012_Overworld/007_Overworld_DayCare.rb
+++ b/Data/Scripts/012_Overworld/007_Overworld_DayCare.rb
@@ -215,7 +215,7 @@ def pbDayCareGenerateEgg
     movemother = father
   end
   # Initial Moves
-  initialmoves = egg.getMLStandard
+  initialmoves = egg.getMoveList
   for k in initialmoves
     if k[0] <= Settings::EGG_LEVEL
       moves.push(k[1])
@@ -395,7 +395,7 @@ Events.onStepTaken += proc { |_sender,_e|
     pkmn.exp += 1   # Gain Exp
     next if pkmn.level==oldlevel
     pkmn.calc_stats
-    movelist = pkmn.getMLStandard
+    movelist = pkmn.getMoveList
     for i in movelist
       pkmn.learn_move(i[1]) if i[0]==pkmn.level   # Learned a new move
     end

--- a/Data/Scripts/013_Items/001_Item_Utilities.rb
+++ b/Data/Scripts/013_Items/001_Item_Utilities.rb
@@ -167,7 +167,7 @@ def pbChangeLevel(pkmn, newlevel, scene)
     pbTopRightWindow(_INTL("Max. HP<r>{1}\r\nAttack<r>{2}\r\nDefense<r>{3}\r\nSp. Atk<r>{4}\r\nSp. Def<r>{5}\r\nSpeed<r>{6}",
                            pkmn.totalhp, pkmn.attack, pkmn.defense, pkmn.spatk, pkmn.spdef, pkmn.speed), scene)
     # Learn new moves upon level up
-    movelist = pkmn.getMLStandard
+    movelist = pkmn.getMoveList
     for i in movelist
       next if i[0] != pkmn.level
       pbLearnMove(pkmn, i[1], true) { scene.pbUpdate }

--- a/Data/Scripts/014_Pokemon/001_Pokemon.rb
+++ b/Data/Scripts/014_Pokemon/001_Pokemon.rb
@@ -1118,8 +1118,12 @@ class Pokemon
 
   # Returns the list of moves this Pokémon can learn by levelling up.
   # @return [Array<Array<Integer,Symbol>>] this Pokémon's move list, where every element is [level, move ID]
-  #KurayX Makes it so it also takes the pre-evo's moves.
   def getMoveList
+    return species_data.moves
+  end
+
+  #KurayX Makes it so it also takes the pre-evo's moves.
+  def getMoveRelearnerList
     kuraymoves = species_data.moves.clone
     kuraychecking = species
     while true
@@ -1128,15 +1132,10 @@ class Pokemon
         break
       end
       kurayoldmoves = GameData::Species.get(checkspecie).moves
-      kuraymoves.push(*kurayoldmoves)
+      kuraymoves.unshift(*kurayoldmoves)
       kuraychecking = checkspecie
     end
     return kuraymoves
-  end
-
-  #KurayX Prevent duplication of asking again and again if pokemon should learn this move
-  def getMLStandard
-    return species_data.moves
   end
 
   # Sets this Pokémon's movelist to the default movelist it originally had.
@@ -1242,10 +1241,11 @@ class Pokemon
       species_data.egg_moves.include?(move_data.id)
   end
 
+  # MoveRelearner check
   def can_relearn_move?
     return false if egg? || shadowPokemon?
     this_level = self.level
-    getMoveList.each { |m| return true if m[0] <= this_level && !hasMove?(m[1]) }
+    getMoveRelearnerList.each { |m| return true if m[0] <= this_level && !hasMove?(m[1]) }
     @first_moves.each { |m| return true if !hasMove?(m) }
     return false
   end

--- a/Data/Scripts/016_UI/001_Non-interactive UI/004_UI_Evolution.rb
+++ b/Data/Scripts/016_UI/001_Non-interactive UI/004_UI_Evolution.rb
@@ -656,7 +656,7 @@ class PokemonEvolutionScene
     end
 
     # Learn moves upon evolution for evolved species
-    movelist = @pokemon.getMLStandard
+    movelist = @pokemon.getMoveList
     for i in movelist
       next if i[0]!=0 && i[0]!=@pokemon.level   # 0 is "learn upon evolution"
       pbLearnMove(@pokemon,i[1],true) { pbUpdate }

--- a/Data/Scripts/016_UI/021_UI_MoveRelearner.rb
+++ b/Data/Scripts/016_UI/021_UI_MoveRelearner.rb
@@ -163,7 +163,7 @@ class MoveRelearnerScreen
   def pbGetRelearnableMoves(pkmn)
     return [] if !pkmn || pkmn.egg? || pkmn.shadowPokemon?
     moves = []
-    pkmn.getMoveList.each do |m|
+    pkmn.getMoveRelearnerList.each do |m|
       next if m[0] > pkmn.level || pkmn.hasMove?(m[1])
       moves.push(m[1]) if !moves.include?(m[1])
     end


### PR DESCRIPTION
This restores `getMoveList` to its original state and scraps `getMLStandard`. The pre-evolution move relearner feature is now in `getMoveRelearnerList`. This fixes a bug where wild pokemon and unfused pokemon start with 4 moves of their lowest stage pre-evolution because of the reference to the altered `getMoveList`. Also `kuraymoves.push` is changed to `kuraymoves.unshift` just for the tidiness of pre-evolution moves appearing first at the move relearner.