### PR TITLE
stops level cap from being applied to NPC trainers

### DIFF
--- a/Data/Scripts/014_Pokemon/001_Pokemon.rb
+++ b/Data/Scripts/014_Pokemon/001_Pokemon.rb
@@ -566,7 +566,7 @@ class Pokemon
   def level
     @level = growth_rate.level_from_exp(@exp) if !@level
     #Kurayx LevelCAP
-    if $PokemonSystem.kuraylevelcap != 0
+    if $PokemonSystem.kuraylevelcap != 0 && (@owner.id == $Trainer.id || @obtain_method == 2) # obtained from trade
       levelcap = getkuraylevelcap()
       if @iv
         calc_stats_sp(levelcap)


### PR DESCRIPTION
The level cap now only applies if the pokemon's OT is the player trainer, or if the pokemon was obtained in a trade. The condition for traded pokemon is necessary because they would otherwise evade the level cap.

I've only tested this against the elite four, which worked. Edge cases I can think of are:
Some NPCs might not set the OT for their pokemon, in which case it would default to the player OT and get levelcapped.
Some player pokemon might have a foreign OT, but not be flagged as obtained from a trade and thus evade the level cap.