### PR TITLE
fixes variables being used before they exist in the Pokemon initializer

### DIFF
--- a/Data/Scripts/014_Pokemon/001_Pokemon.rb
+++ b/Data/Scripts/014_Pokemon/001_Pokemon.rb
@@ -566,17 +566,12 @@ class Pokemon
   def level
     @level = growth_rate.level_from_exp(@exp) if !@level
     #Kurayx LevelCAP
-    # if $PokemonSystem.kuraylevelcap != 0 && (@owner.id == $Trainer.id || @obtain_method == 2) # obtained from trade
-    if $PokemonSystem.kuraylevelcap != 0
+    if $PokemonSystem.kuraylevelcap != 0 && (@owner.id == $Trainer.id || @obtain_method == 2) # obtained from trade
       levelcap = getkuraylevelcap()
-      if @iv
-        calc_stats_sp(levelcap)
-      end
+      calc_stats_sp(levelcap)
       return levelcap if @level > levelcap
     end
-    if @iv
-      calc_stats_sp(@level)
-    end
+    calc_stats_sp(@level)
     return @level
   end
 
@@ -1870,7 +1865,6 @@ class Pokemon
     @time_form_set = nil
     self.level = level
     @steps_to_hatch = 0
-    heal_status
     @gender = nil
     @shiny = nil
     #KurayX - KURAYX_ABOUT_SHINIES
@@ -1892,7 +1886,6 @@ class Pokemon
     @item = nil
     @mail = nil
     @moves = []
-    reset_moves if withMoves
     @first_moves = []
     @ribbons = []
     @cool = 0
@@ -1934,6 +1927,8 @@ class Pokemon
     @personalID = rand(2 ** 16) | rand(2 ** 16) << 16
     @hp = 1
     @totalhp = 1
+    heal_status
+    reset_moves if withMoves
     calc_stats
     if @form == 0 && recheck_form
       f = MultipleForms.call("getFormOnCreation", self)


### PR DESCRIPTION
The pokemon initializer calls `reset_moves`, which uses `level`, which uses `@iv` and `@owner`. This would be fine but some things like `@iv` and `@owner` don't exist because the initializer hasn't gotten to them yet. I moved `reset_moves` and `heal_status` to a later point in the initializer after all the instance variables are set up. This fixes the crash due to starter pokemon having a nil `owner` object during level cap stuff.