### PR TITLE
Pokemon with abilities that are immune to Poison Status in battle will now function in the Overworld. Optionally Poison Heal will heal as well

### DIFF
--- a/Data/Scripts/012_Overworld/001_Overworld.rb
+++ b/Data/Scripts/012_Overworld/001_Overworld.rb
@@ -87,8 +87,7 @@ Events.onStepTakenTransferPossible += proc { |_sender, e|
   if $PokemonGlobal.stepcount % 4 == 0 && Settings::POISON_IN_FIELD
     flashed = false
     for i in $Trainer.able_party
-      #if i.status == :POISON && !i.hasAbility?(:POISONHEAL)
-      if i.status == :POISON && !i.hasAbility?(:IMMUNITY) && ($PokemonSystem.walkingpoison && $PokemonSystem.walkingpoison == 0)
+      if i.status == :POISON && (($PokemonSystem.walkingpoison && $PokemonSystem.walkingpoison == 0) || (!i.hasAbility?(:POISONHEAL) && !i.hasAbility?(:MAGICGUARD) && !i.hasAbility?(:IMMUNITY)))
         if !flashed
           pbFlash(Color.new(163, 73, 164, 128), 8)
           flashed = true
@@ -107,7 +106,6 @@ Events.onStepTakenTransferPossible += proc { |_sender, e|
           handled[0] = true
           pbCheckAllFainted
         end
-      elsif i.status == :POISON && i.hasAbility?(:POISONHEAL) && i.hasAbility?(:MAGICGUARD) && ($PokemonSystem.walkingpoison && $PokemonSystem.walkingpoison == 1)
       elsif i.status == :POISON && i.hasAbility?(:POISONHEAL) && i.hp != i.totalhp && ($PokemonSystem.walkingpoison && $PokemonSystem.walkingpoison == 2)
         i.hp += 1
       end

--- a/Data/Scripts/012_Overworld/001_Overworld.rb
+++ b/Data/Scripts/012_Overworld/001_Overworld.rb
@@ -87,7 +87,8 @@ Events.onStepTakenTransferPossible += proc { |_sender, e|
   if $PokemonGlobal.stepcount % 4 == 0 && Settings::POISON_IN_FIELD
     flashed = false
     for i in $Trainer.able_party
-      if i.status == :POISON && !i.hasAbility?(:IMMUNITY)
+      #if i.status == :POISON && !i.hasAbility?(:POISONHEAL)
+      if i.status == :POISON && !i.hasAbility?(:IMMUNITY) && ($PokemonSystem.walkingpoison && $PokemonSystem.walkingpoison == 0)
         if !flashed
           pbFlash(Color.new(163, 73, 164, 128), 8)
           flashed = true
@@ -106,6 +107,9 @@ Events.onStepTakenTransferPossible += proc { |_sender, e|
           handled[0] = true
           pbCheckAllFainted
         end
+      elsif i.status == :POISON && i.hasAbility?(:POISONHEAL) && i.hasAbility?(:MAGICGUARD) && ($PokemonSystem.walkingpoison && $PokemonSystem.walkingpoison == 1)
+      elsif i.status == :POISON && i.hasAbility?(:POISONHEAL) && i.hp != i.totalhp && ($PokemonSystem.walkingpoison && $PokemonSystem.walkingpoison == 2)
+        i.hp += 1
       end
     end
   end

--- a/Data/Scripts/016_UI/015_UI_Options.rb
+++ b/Data/Scripts/016_UI/015_UI_Options.rb
@@ -102,6 +102,9 @@ class PokemonSystem
   
   attr_accessor :dexspriteselect
 
+  #Blue Wuppo
+  attr_accessor :walkingpoison
+
   def initialize
     # Vanilla Global
     @raiser = 1
@@ -180,6 +183,7 @@ class PokemonSystem
     else
       @shinyodds = 16
     end
+    @walkingpoison = 0
   end
 
   def load_bootup_data(saved)
@@ -259,6 +263,7 @@ class PokemonSystem
     @nopngexport = saved.nopngexport if saved.nopngexport
     @nopngimport = saved.nopngimport if saved.nopngimport
     @legendarybreed = saved.legendarybreed if saved.legendarybreed
+    @walkingpoison = saved.walkingpoison if saved.walkingpoison
   end
 end
 
@@ -1358,6 +1363,13 @@ class KurayOptSc_2 < PokemonOption_Scene
                       proc { |value| $PokemonSystem.legendarybreed = value },
                       ["Legendary Head cannot breed (like new PIF).",
                       "Legendary Head can breed (like old PIF)."]
+    )
+    options << EnumOption.new(_INTL("Overworld Poison"), [_INTL("Off"), _INTL("On"), _INTL("On+Healing")],
+                      proc { $PokemonSystem.walkingpoison },
+                      proc { |value| $PokemonSystem.walkingpoison = value },
+                      ["Vanilla PIF functionality.",
+                      "Abilities that disable Poison Damage in Battle will function in the Overworld.",
+                      "Same as previous option, except Poison Heal will now Heal your Pokemon."]
     )
 
     return options


### PR DESCRIPTION
Edited the overworld.rb script that handles poison damage when walking with a poisoned party pokemon. There are 3 options, Off (Vanilla behavior), On (just immunity), and On + Healing (Same as On, but PoisonHeal heals the pokemon instead). Playtested and found no bugs